### PR TITLE
utilize process.env

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -29,8 +29,15 @@ We welcome contributions to the SOAD project. Here are some ways you can help:
 
 4. Start the frontend (React) server
 
-    NOTE: right now you will have to edit this line in `src/axiosInstance.js` file locally to point to `http://localhost:8000`:
-    https://github.com/r0fls/soad/blob/main/trading-dashboard/src/axiosInstance.js#L4
+    Create a file called `/trading-dashboard/.env.local` with this line:
+    ```
+    REACT_APP_API_URL=http://localhost:8000
+    ```
+
+    To prevent `package.json` from [unexpectedly changing](https://github.com/nodejs/corepack/issues/485) set this environment variable:
+    ```
+    COREPACK_ENABLE_AUTO_PIN=0
+    ```
 
     Then:
 

--- a/trading-dashboard/src/axiosInstance.js
+++ b/trading-dashboard/src/axiosInstance.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import history from './history';
 
-const baseURL = '$REACT_API_URL';
+const baseURL = process.env.REACT_APP_API_URL || '$REACT_API_URL';
 
 const axiosInstance = axios.create({
   baseURL: baseURL,


### PR DESCRIPTION
The trick is process.env only works if the name starts with REACT_APP

Base .env still has REACT_API_URL  since it's used in docker scripts. 

This could be cleaned up a little bit more by also updating docker scripts to use the longer  REACT_APP_API_URL version of the env var, but this was got it to where I don't have an extra changed file axiosInstance.js in my working folder.

I also updated documentation a little bit. There is a thing to prevent package.json from changing every time `yarn start` is launched. There's a [lively discussion](https://github.com/nodejs/corepack/issues/485) regarding what is happening there. You might not be experiencing that if your nodejs or npm is older.

I hope my PR are beneficial. I'm still getting familiar with the project.